### PR TITLE
pin pip version on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   - pip
   
 before_install:
-  - pip install --upgrade pip
+  - pip install --upgrade pip==20.0.1
 
 install:
   - pip install -r requirements/travis.txt


### PR DESCRIPTION
This should fix the failures like:

```
    from pip._internal.download import PipSession
338ImportError: No module named download
```